### PR TITLE
fix: a bug with node9x

### DIFF
--- a/lib/download.js
+++ b/lib/download.js
@@ -17,7 +17,7 @@ class RoiDownload extends Base {
           response.pipe(stream);
           stream.on('finish', () => {
             resolve(response);
-            stream.close();
+            stream.end();
           });
         } else {
           options.endpoint = response.headers.location;


### PR DESCRIPTION
the correct way is to call stream.end() instead
stream.close()

Connects to #35 